### PR TITLE
build: Disable spring boot build of a plain jar

### DIFF
--- a/buildSrc/src/main/groovy/diceware.springboot-conventions.gradle
+++ b/buildSrc/src/main/groovy/diceware.springboot-conventions.gradle
@@ -8,3 +8,7 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-web')
   testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
+
+tasks.named("jar") {
+	enabled = false
+}


### PR DESCRIPTION
By default, the spring boot gradle creates a plain jar alongside the executable jarfile. Disable this in the shared configuration.

Closes #34 